### PR TITLE
Fix unbound variable error in install script trap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ main() {
   # Create temp directory
   local tmp_dir
   tmp_dir=$(mktemp -d)
-  trap 'rm -rf "$tmp_dir"' EXIT
+  trap "rm -rf '$tmp_dir'" EXIT
 
   # Clone repo
   echo "Fetching skill..."


### PR DESCRIPTION
When running either the global or local install script, I got an error back:

```sh
$ curl -fsSL https://raw.githubusercontent.com/dmmulroy/cloudflare-skill/main/install.sh | bash -s -- --global
Installing cloudflare skill (global)...
Fetching skill...
Installed skill to: /Users/kristian/.config/opencode/skill/cloudflare
Installed command to: /Users/kristian/.config/opencode/command/cloudflare.md
Done.
bash: line 89: tmp_dir: unbound variable
```

Threw opencode at it for the fix! Verified that running works locally after the change:

```sh
$ ./install.sh --global
Installing cloudflare skill (global)...
Fetching skill...
Updating existing installation...
Installed skill to: /Users/kristian/.config/opencode/skill/cloudflare
Installed command to: /Users/kristian/.config/opencode/command/cloudflare.md
Done.
```